### PR TITLE
Use logarithmic colorbar axis in z-log mode

### DIFF
--- a/plotpy/plot/base.py
+++ b/plotpy/plot/base.py
@@ -2534,7 +2534,16 @@ class BasePlot(qwt.QwtPlot):
             return
         zaxis = self.colormap_axis
         axiswidget: QwtScaleWidget = self.axisWidget(zaxis)
-        self.setAxisScale(zaxis, item.min, item.max)
+
+        zmin, zmax = item.min, item.max
+
+        if hasattr(item, "get_zaxis_log_state") and item.get_zaxis_log_state():
+            zmin, zmax = 10**zmin, 10**zmax
+            self.setAxisScaleEngine(zaxis, qwt.QwtLogScaleEngine())
+        else:
+            self.setAxisScaleEngine(zaxis, qwt.QwtLinearScaleEngine())
+
+        self.setAxisScale(zaxis, zmin, zmax)
         # XXX: The colormap can't be displayed if min>max, to fix this
         # we should pass an inverted colormap along with _max, _min values
         axiswidget.setColorMap(


### PR DESCRIPTION
Hi!

This PR changes the colorbar axis when using the z-log scale mode for `ImageItem` to be logarithmic and show the original intensity values.

Previously, when log scaling was enabled, the colorbar labels displayed the logarithmic values (`log10`) instead of the original image intensities. While the logarithmic transformation is useful for color mapping and visualization, showing the transformed values in the legend is confusing in scientific applications, where users are usually interested in the original physical intensities.

With this change:
- the image rendering still uses logarithmic scaling for color mapping,
- but the colorbar axis now displays the original intensity values using a logarithmic axis scale.

This keeps the visualization behaviour while making the displayed values more meaningful for users.

There may be a better architectural approach for handling this, but this solution keeps the changes minimal and avoids modifying the existing rendering logic.

Best regards,
Oriol